### PR TITLE
fetch instances directly

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -51,6 +51,7 @@ export default {
   },
   mounted() {
     this.$store.dispatch('user/getUser')
+    this.$store.dispatch('instances/fetchInstances')
     this.$refs.app.classList += ` ${this.getThemeClass()}`
     if (process.browser) {
       window.addEventListener('scroll', this.handleScroll, { passive: true })

--- a/store/instances.js
+++ b/store/instances.js
@@ -1,13 +1,6 @@
 export const state = () => ({
   currentInstance: 'https://invidious.snopyta.org',
-  instances: [
-    'https://invidious.snopyta.org',
-    'https://invidio.us',
-    'https://invidiou.sh',
-    'https://invidious.ggc-project.de',
-    'https://yewtu.be',
-    'https://invidious.toot.koeln'
-  ]
+  instances: ['https://invidious.snopyta.org']
 })
 export const getters = {
   currentInstance(state) {
@@ -20,5 +13,29 @@ export const getters = {
 export const mutations = {
   changeInstance(state, instance) {
     state.currentInstance = instance
+  },
+  addInstance(state, instance) {
+    state.instances.push(instance);
+  }
+}
+export const actions = {
+  fetchInstances({ commit }) {
+    this.$axios
+      .get('https://raw.githubusercontent.com/wiki/iv-org/invidious/Invidious-Instances.md')
+      .then(response => {
+        var fetchData = response.data.split("### Blocked:")[0];
+        fetchData = fetchData.split("### Blocked:")[0];
+        const regex = /\[(?<host>[^ \]]+)\]\((?<uri>[^\)]+)\)(?! - offline)/g;
+        const matches = [...fetchData.matchAll(regex)];
+        for (const match of matches) {
+          if (!match[2].includes(".onion") && !match[2].includes(".i2p")) {
+            if (match[2].endsWith("/")) {
+              commit('addInstance', match[2].substring(0, match[2].length-1));
+            } else {
+              commit('addInstance', match[2]);
+            }
+          }
+        }
+      })
   }
 }


### PR DESCRIPTION
The Instances list is now being fetched directyl from the wiki at https://raw.githubusercontent.com/wiki/iv-org/invidious/Invidious-Instances.md. This function was based upon the instances.invidious.us site, which is now becoming unsupported.

Right now this list is only reading the entries and not actually checking their health.